### PR TITLE
Geracao de objeto da biblioteca raygui removido

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,11 @@
-CFLAGS = -Wall -Wextra
-DEPS = -lraylib -lraygui
+CFLAGS = -Wall
+DEPS = -lraylib -lm
 
 CC = gcc
 
 INCLUDE = ./include 
 
 RL_LDD = $(PWD)/bibliotecas/raylib-5.5_linux_amd64/lib
-RG_LDD = $(PWD)/bibliotecas/raygui-4.0/src
-
 RL_INC = ./bibliotecas/raylib-5.5_linux_amd64/include
 RG_INC = ./bibliotecas/raygui-4.0/src
 
@@ -16,7 +14,7 @@ OBJS = save.o dialogo.o main.o
 all: ./build/logicus
 
 ./build/logicus: $(OBJS)
-	gcc $(CFLAGS) $(OBJS) -o ./build/logicus -L$(RL_LDD) -L$(RG_LDD) -Wl,-rpath=$(RL_LDD) -Wl,-rpath=$(RG_LDD) $(DEPS)
+	gcc $(CFLAGS) $(OBJS) -o ./build/logicus -L$(RL_LDD) -Wl,-rpath=$(RL_LDD) $(DEPS)
 
 main.o: ./src/main.c
 	$(CC) $(CFLAGS) -c ./src/main.c -I$(RL_INC) -I$(RG_INC) -I$(INCLUDE)

--- a/configurar_linux.sh
+++ b/configurar_linux.sh
@@ -9,9 +9,3 @@ wget https://github.com/raysan5/raylib/releases/download/5.5/raylib-5.5_linux_am
 
 unzip ./bibliotecas/4.0.zip -d ./bibliotecas/
 tar -xvf ./bibliotecas/raylib-5.5_linux_amd64.tar.gz -C ./bibliotecas/
-
-mv ./bibliotecas/raygui-4.0/src/raygui.h ./bibliotecas/raygui-4.0/src/raygui.c
-
-gcc -o ./bibliotecas/raygui-4.0/src/libraygui.so ./bibliotecas/raygui-4.0/src/raygui.c -I./bibliotecas/raylib-5.5_linux_amd64/include -L./bibliotecas/raylib-5.5_linux_amd64/lib -shared -fpic -DRAYGUI_IMPLEMENTATION -lraylib -lm -lpthread -ldl -lrt
-
-mv ./bibliotecas/raygui-4.0/src/raygui.c ./bibliotecas/raygui-4.0/src/raygui.h

--- a/src/main.c
+++ b/src/main.c
@@ -4,6 +4,8 @@
 
 // importacao de arquivos header de bibliotecas third party
 
+#define RAYGUI_IMPLEMENTATION
+
 #include "raylib.h"
 #include "raygui.h"
 
@@ -20,23 +22,9 @@ int main(void) {
     InitWindow(800, 460, "Logicus;");
     SetTargetFPS(60);
 
-    bool showMessageBox = false;
-
-    while (!WindowShouldClose())
-    {
+    while (!WindowShouldClose()) {
         BeginDrawing();
             ClearBackground(GetColor(GuiGetStyle(DEFAULT, BACKGROUND_COLOR)));
-
-            if (GuiButton((Rectangle){ 24, 24, 120, 30 }, "#191#Show Message")) showMessageBox = true;
-
-            if (showMessageBox)
-            {
-                int result = GuiMessageBox((Rectangle){ 85, 70, 250, 100 },
-                    "#191#Message Box", "Hi! This is a message!", "Nice;Cool");
-
-                if (result >= 0) showMessageBox = false;
-            }
-
         EndDrawing();
     }
 


### PR DESCRIPTION
O script `configurar_linux.sh` gerava um objeto da biblioteca `raygui` para linkar posteriormente.

Pelo funcionamento do raygui, essa etapa é desnecessária pois as implementações do raygui já estão no arquivo `raygui.h`.