### PR TITLE
Correcao de bug que impossibilita encontrar recursos

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -34,6 +34,9 @@ int main(void) {
     InitWindow(LARGURA, ALTURA, "Logicus;");
     SetTargetFPS(60);
 
+    const char *diretorioExecutavel = GetApplicationDirectory();
+    ChangeDirectory(diretorioExecutavel);
+
     // carrega recursos de imagem do jogo
     carregarRecursos(&imagens);
 

--- a/src/recursos.c
+++ b/src/recursos.c
@@ -1,4 +1,6 @@
+#include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "raylib.h"
 
@@ -15,8 +17,8 @@ Texture2D carregarImagem(int nome, char *arquivo) {
 
 void carregarRecursos(Imagens *imagens) {
     // imagens de cenario
-    imagens->interface[SPLASH_ARTE] = carregarImagem(SPLASH_ARTE, "./imagens/arte_splash.png");
-    imagens->interface[TITULO_ARTE] = carregarImagem(TITULO_ARTE, "./imagens/arte_titulo.png");
+    imagens->interface[SPLASH_ARTE] = carregarImagem(SPLASH_ARTE, "../imagens/arte_splash.png");
+    imagens->interface[TITULO_ARTE] = carregarImagem(TITULO_ARTE, "../imagens/arte_titulo.png");
 
     // imagens interface
     // ..


### PR DESCRIPTION
Quando executado, raylib usa de referência o ponto de onde o jogo é executado para buscar as imagens. Desse modo, quando o jogo é executado do diretório principal ou de dentro da pasta `build`, isso causa com que seja necessário caminhis diferentes para alcançar a pasta `imagens`.

Assim, essa mudança faz com que sempre onde está o executável seja o inicio da busca. Como o executável sempre estará na pasta `build`, é dali que iniciará a busca por `imagens`.