### PR TITLE
HOTFIX: segfault no carregamento de saves

### DIFF
--- a/include/save.h
+++ b/include/save.h
@@ -4,6 +4,8 @@
 #ifndef SAVE_H
 #define SAVE_H
 
+#include "telas.h"
+
 typedef struct {
     char nomeUsuario[64];
 
@@ -18,9 +20,8 @@ extern SaveEstado *saveEmUso;
 extern int slotAtivo;
 extern SaveEstado saveSlots[3];
 
-bool salvarEstadoDeJogo(SaveEstado *estado, int slot);
-bool carregarEstadoDeJogo(SaveEstado *estado, int slot);
-EstadoTela telaSlotsSave(Imagens *imagens);
-void inicializarSistemaDeSave(void);
+void salvarEstadoDeJogo(SaveEstado *estado, int slot);
+void carregarEstadoDeJogo(SaveEstado *estado, int slot);
+void inicializarSistemaDeSave(SaveEstado *saveSlots);
 
 #endif // SAVE_H

--- a/include/telas.h
+++ b/include/telas.h
@@ -2,6 +2,7 @@
 #define TELAS_H
 
 #include "recursos.h"
+#include "save.h"
 
 typedef enum {
     TELA_INICIAL = 0,
@@ -23,5 +24,6 @@ EstadoTela telaMenu(EstadoTela *tela, Imagens *imagens, int LARGURA, int ALTURA)
 EstadoTela telaJogo(EstadoTela *tela, Imagens *imagens, int LARGURA, int ALTURA, int *idSalaAtual);
 EstadoTela telaMapa(EstadoTela *tela, Imagens *imagens, int LARGURA, int ALTURA, int *idSalaAtual);
 EstadoTela telaInput(EstadoTela *tela, Imagens *imagens, int LARGURA, int ALTURA);
+EstadoTela telaSlotsSave(Imagens *imagens);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -26,14 +26,14 @@
 #define ALTURA 480
 
 // declaracao de variaveis globais
-// ...
 
 // vetor com a quantidade de slots de save acessiveis para o usuario
 
 int main(void) {
-    // carrega saves de jogo existentes
-    inicializarSistemaDeSave();
 
+    // carrega saves de jogo existentes
+    inicializarSistemaDeSave(saveSlots);
+ 
     // aloca estaticamente memoria para recursos de imagem
     Imagens imagens = {0};
     

--- a/src/save.c
+++ b/src/save.c
@@ -13,19 +13,10 @@
 #define LARGURA 480
 
 // estrutura com campos de informacao de um save especifico
-typedef struct {
-    char nomeUsuario[64];
-
-    int pontuacao;
-    EstadoTela fase;
-    int dialogoAtual;
-    bool ativo;
-} SaveEstado;
 
 int slotAtivo = -1;
-
+SaveEstado *saveEmUso;
 SaveEstado saveSlots[3];
-SaveEstado *saveEmUso = NULL;
 
 void salvarEstadoDeJogo(SaveEstado *estado, int slot) {
     char arquivo[256];
@@ -53,7 +44,7 @@ void carregarEstadoDeJogo(SaveEstado *estado, int slot) {
     snprintf(arquivo, 256, "saves/slot%d", slot);
 
     printf("LOG: carregando save: %s\n", arquivo);
-
+    
     // abrir arquivo binario para leitura
     FILE *f = fopen(arquivo, "rb");
 
@@ -69,9 +60,19 @@ void carregarEstadoDeJogo(SaveEstado *estado, int slot) {
     fclose(f);
 }
 
-void inicializarSistemaDeSave(void) {
+void inicializarSistemaDeSave(SaveEstado *saveSlots) {
     for (int i = 0; i < 3; ++i) {
-        carregarEstadoDeJogo(&saveSlots[i], i);
+        char nome[32];
+        snprintf(nome, 32, "saves/slot%d", i);
+
+        FILE *f = fopen(nome, "rb");
+        if (f == NULL) {
+            FILE *fp = fopen("nome", "wb");
+            fclose(fp);
+            continue;
+        }
+
+        fread(&saveSlots[i], sizeof(SaveEstado), 1, f);
     }
 }
 


### PR DESCRIPTION
Erro `Segmentation Fault` ocorria quando o jogo tentava carregar os arquivos de saves inexistentes.

Uma correção rápida foi feita para que a função de inicialização do sistema de save crie automaticamente estes arquivos caso nao existam.