### PR TITLE
fix: nao gerar arquivo nome ao iniciar o jogo

### DIFF
--- a/src/save.c
+++ b/src/save.c
@@ -62,17 +62,17 @@ void carregarEstadoDeJogo(SaveEstado *estado, int slot) {
 
 void inicializarSistemaDeSave(SaveEstado *saveSlots) {
     for (int i = 0; i < 3; ++i) {
-        char nome[32];
-        snprintf(nome, 32, "saves/slot%d", i);
+        char caminho[32];
+        snprintf(caminho, 32, "saves/slot%d", i);
 
-        FILE *f = fopen(nome, "rb");
+        FILE *f = fopen(caminho, "rb");
         if (f == NULL) {
-            FILE *fp = fopen("nome", "wb");
-            fclose(fp);
+            // Slot ainda nao existe; nada a carregar.
             continue;
         }
 
         fread(&saveSlots[i], sizeof(SaveEstado), 1, f);
+        fclose(f);
     }
 }
 


### PR DESCRIPTION
## Summary
- Em `inicializarSistemaDeSave`, slots inexistentes usavam `fopen(\"nome\", \"wb\")`, criando um arquivo literal chamado `nome` na raiz do projeto
- Agora o init apenas ignora slots ausentes e fecha o arquivo apos carregar um slot existente

Closes #54.

## Test plan
- [ ] Remover qualquer arquivo `nome` residual na raiz
- [ ] Iniciar o jogo sem saves em um ou mais slots
- [ ] Confirmar que nenhum arquivo `nome` e criado
- [ ] Confirmar que saves existentes em `saves/slotN` ainda carregam normalmente